### PR TITLE
Precision Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ nano_gpt.egg-info
 # sandbox
 *.pt
 /nano_gpt.egg-info
-/nano_gpt.egg-info

--- a/model/layers/FeedForwardNetwork.py
+++ b/model/layers/FeedForwardNetwork.py
@@ -37,7 +37,7 @@ class FeedForward(nn.Module):
         device = self.device
 
         # Set model precision to default with a warning
-        if model_precision not in [torch.float32, torch.float64, torch.float16, torch.bfloat16,torch.float8_e4m3fn,torch.float8_e5m2]:
+        if model_precision not in [torch.float32, torch.float64, torch.float16, torch.bfloat16]:
             warnings.warn("Defaulting to torch.float32, {model_precision} is not a valid dtype")
             self.model_precision = torch.float32
 

--- a/model/layers/FeedForwardNetwork.py
+++ b/model/layers/FeedForwardNetwork.py
@@ -1,13 +1,23 @@
 import torch 
 from torch import nn
 from torch.nn import functional as F
+import warnings
 
 class FeedForward(nn.Module):
     """
     A single MLP followed by non-linearity
     """
 
-    def __init__(self, attention_size: int = 16, dropout: float = 0.2, device: str=None):
+    def __init__(self, attention_size: int = 16, dropout: float = 0.2, device: str=None, model_precision = torch.float32):
+        """
+        Function: initialises a simple feed forward nn
+        Args:
+            attention_size (int): The projection dimension of all attention heads combined
+            dropout (float): The value of dropout to be added at end of each layer
+            device (str): The device on which the operation must be carried out `cuda` or `cpu`
+            model_precision : Define the model float precision
+        """
+        
         super().__init__()
 
         # Validate attention head size 
@@ -15,7 +25,6 @@ class FeedForward(nn.Module):
             attention_size = int(attention_size)
         except Exception as e:
             raise TypeError("The argument `attention_size` must be of type int.") from e
-        
 
         # Determine the device type
         if device is None:
@@ -27,12 +36,22 @@ class FeedForward(nn.Module):
 
         device = self.device
 
+        # Set model precision to default with a warning
+        if model_precision not in [torch.float32, torch.float64, torch.float16, torch.bfloat16,torch.float8_e4m3fn,torch.float8_e5m2]:
+            warnings.warn("Defaulting to torch.float32, {model_precision} is not a valid dtype")
+            self.model_precision = torch.float32
+
+        else:
+            self.model_precision = model_precision
+
+        model_precision = self.model_precision
+
         self.net = nn.Sequential(
             nn.Linear(attention_size, attention_size * 4),
             nn.GELU(),
             nn.Linear(attention_size * 4, attention_size),
             nn.Dropout(dropout)
-        ).to(device=device)
+        ).to(device=device, dtype=model_precision)
 
     def forward(self, x):
         return self.net(x)

--- a/model/models.py
+++ b/model/models.py
@@ -19,7 +19,7 @@ class LanguageModel(nn.Module):
                  num_layers: int = 6, 
                  dropout: float = 0.2, 
                  positional_encoder_type: str = "sinusoidal",
-                 model_precision = torch.float32):
+                 model_precision: str = "float32"):
         """
         Function: Instances an object of class `LanguageModel`
         Args:
@@ -48,12 +48,18 @@ class LanguageModel(nn.Module):
         device = self.device
 
         # Set model precision to default with a warning
-        if model_precision not in [torch.float32, torch.float64, torch.float16, torch.bfloat16]:
+        if model_precision not in ["float32", "float64", "float16", "bfloat16"]:
             warnings.warn("Defaulting to torch.float32, {model_precision} is not a valid dtype")
             self.model_precision = torch.float32
 
         else:
-            self.model_precision = model_precision
+            precison_types = {
+                "float32": torch.float32, 
+                "float64": torch.float64, 
+                "float16": torch.float16, 
+                "bfloat16": torch.bfloat16
+            }
+            self.model_precision = precison_types[model_precision]
 
         model_precision = self.model_precision
 
@@ -64,7 +70,7 @@ class LanguageModel(nn.Module):
         # Set `positional_encoder_type` to naive
         elif positional_encoder_type == "naive":
             self.positional_encoder_type = "naive"
-            self.position_embedding_table = nn.Embedding(block_size, n_embedd).to(device=device)
+            self.position_embedding_table = nn.Embedding(block_size, n_embedd).to(device=device, dtype=model_precision)
 
         # Set `positional_encoder_type` to sinusoidal
         elif positional_encoder_type == "sinusoidal":

--- a/pipelines/training/lazy_batch_training.py
+++ b/pipelines/training/lazy_batch_training.py
@@ -287,9 +287,9 @@ def lazy_batch_training(
     elif not isinstance(model_params, dict):
         raise TypeError("Argument `model_params` must be of type dict")
 
-    elif not set(list(model_params.keys())).issuperset(set(['block_size', 'n_embedd', 'attention_size', 'num_heads', 'num_layers', 'dropout', 'positional_encoder_type'])):
+    elif not set(list(model_params.keys())).issuperset(set(['model_precision','block_size', 'n_embedd', 'attention_size', 'num_heads', 'num_layers', 'dropout', 'positional_encoder_type'])):
         raise ValueError("Argument `model_params` must be a dictionary with the following keys 'block_size', 'n_embedd', 'attention_size', 'num_heads', 'num_layers', 'dropout', 'positional_encoder_type'")
-            
+
     # Initialise a model class
     try:
         model = LanguageModel(
@@ -301,6 +301,7 @@ def lazy_batch_training(
             num_layers=model_params['num_layers'],
             dropout=model_params['dropout'],
             positional_encoder_type=model_params['positional_encoder_type'],
+            model_precision=model_params['model_precision'],
             device=device
         )
         model = model.to(device=device)
@@ -370,9 +371,12 @@ def lazy_batch_training(
         "tokenizer_type" : "tiktoken",
         "tokenizer_encoding" : tokenizer_encoding,
         "vocab_size" : tokenizer_vocab_size,
-        "positional_encoder_type" : model_params['positional_encoder_type']
+        "positional_encoder_type" : model_params['positional_encoder_type'],
+        "model_precision" : model_params['model_precision']
     }
     
+
+
     # Parsing the model and optimizer to the training theory
     model, losses = lazy_batch_trainer(dir_path=array_directory,
                                        model=model,

--- a/positional_encoders/sinusoidal_positional_encoding.py
+++ b/positional_encoders/sinusoidal_positional_encoding.py
@@ -1,13 +1,14 @@
 import torch
 from torch import nn
 
-def SinusoidalPositionalEncoding(T: int, n_embedd: int, n: int = 10_000, device: str = "cpu"):
+def SinusoidalPositionalEncoding(T: int, n_embedd: int, n: int = 10_000, device: str = "cpu", model_precision = torch.float32):
     """
     Function: Retrieves Sinusoidal Positional encoding for various dimensions
     Args:
         x (torch.Tensor): The vector to be positionally encoded
         n_embedd (int): Linear dimension in which the token in projected into
         device (str): The device on which the operation must be carried out `cuda` or `cpu`
+        model_precision : Define the model float precision
     """
     
     # If the n_embedd is odd raise error
@@ -19,11 +20,11 @@ def SinusoidalPositionalEncoding(T: int, n_embedd: int, n: int = 10_000, device:
     embeddings = torch.zeros(T, n_embedd).to(device=device)
 
     # Calculate denominator map
-    denom = torch.pow(n, 2*torch.arange(0, n_embedd//2)/n_embedd).to(device=device)
+    denom = torch.pow(n, 2*torch.arange(0, n_embedd//2)/n_embedd).to(device=device, dtype=model_precision)
 
     # Update embedding
-    embeddings[:, 0::2] = torch.sin(positions/denom).to(device=device)
-    embeddings[:, 1::2] = torch.cos(positions/denom).to(device=device)
-
+    embeddings[:, 0::2] = torch.sin(positions/denom).to(device=device, dtype=model_precision)
+    embeddings[:, 1::2] = torch.cos(positions/denom).to(device=device, dtype=model_precision)
+    
     # Get embedding map
-    return torch.tensor(embeddings).to(device=device)
+    return torch.tensor(embeddings).to(device=device, dtype=model_precision)

--- a/runs/run-0020/model/params.json
+++ b/runs/run-0020/model/params.json
@@ -1,1 +1,17 @@
-{"block_size": 512, "batch_size": 6, "split_ratio": 0.9, "steps": 2500, "max_tokens": 512, "learning_rate": 0.001, "n_embedd": 128, "attention_size": 128, "dropout": 0.2, "num_layers": 6, "num_heads": 8, "tokenizer_type": "tiktoken", "tokenizer_encoding": "cl100k_base", "vocab_size": 100280, "positional_encoder_type": "RoPE"}
+{
+    "block_size": 512,
+    "batch_size": 6,
+    "split_ratio": 0.9,
+    "steps": 2500,
+    "max_tokens": 512,
+    "learning_rate": 0.001,
+    "n_embedd": 128,
+    "attention_size": 128,
+    "dropout": 0.2,
+    "num_layers": 6,
+    "num_heads": 8,
+    "tokenizer_type": "tiktoken",
+    "tokenizer_encoding": "cl100k_base",
+    "vocab_size": 100280,
+    "positional_encoder_type": "RoPE"
+}

--- a/sandbox/sandbox-lazy-batch-training-pipeline.py
+++ b/sandbox/sandbox-lazy-batch-training-pipeline.py
@@ -1,4 +1,5 @@
 from pipelines.training.lazy_batch_training import lazy_batch_training 
+import torch
 
 # Data Params
 data_path = "./data_archive/ROOTS.txt"
@@ -23,13 +24,14 @@ model_params = {
     'num_heads': 8,
     'num_layers' : 6,
     'dropout': 0.20,
-    'positional_encoder_type' : 'RoPE'
+    'positional_encoder_type' : 'RoPE', 
+    'model_precision': "float16"
 }
 
 # Model check pointing params
 check_point_params = {
-    'save_steps' : 500,
-    "log_to_mlflow" : True,
+    'save_steps' : 1000,
+    "log_to_mlflow" : False,
     "mlflow_experiment_name": "",
     "mlflow_tracking_uri" :  "",
     "mlflow_model_name" : "",

--- a/trainers/lazy_batch_trainer/trainer.py
+++ b/trainers/lazy_batch_trainer/trainer.py
@@ -16,9 +16,9 @@ def lazy_batch_trainer(dir_path: str, model: torch.nn.Module, optimizer, batch_s
         optimizer : Torch optimizer object used for training the model
         block_size (int): Block size is the maximum context window of the model
         batch_size (int): Batch size is the number of concurrent samples we can load for GPU saturation
-        steps (int) : The number of steps to train the model for 
+        steps (int) : The number of steps to train the model for
         check_point_params (dict): Dictionary contains information about the checkpointing the model
-        device (str) : Set the computational device  
+        device (str) : Set the computational device
         train_ratio (0 < float < 1): The ratio of data to be considered as training data
         model_params (dict): Captures all the model training params
     """
@@ -112,7 +112,7 @@ def lazy_batch_trainer(dir_path: str, model: torch.nn.Module, optimizer, batch_s
 
                     # Log all model params and Hyperparameters
                     for k in model_params.keys():
-                            mlflow.log_param(str(k), model_params[k])
+                        mlflow.log_param(str(k), model_params[k])
 
                     # LLM training loop
                     for step in tqdm(range(steps)):


### PR DESCRIPTION
Added feature to set the precision configuration of the model, currently can handle:

- torch.float32 
- torch.float64 
- torch.float16
- torch.bfloat16

Set the precision in the `sandbox/sandbox-lazy-batch-training-pipeline.py` in the `model_params` key `model_precision` 